### PR TITLE
POM changes and added module-info.java

### DIFF
--- a/.ci-toolchains.xml
+++ b/.ci-toolchains.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0 http://maven.apache.org/xsd/toolchains-1.1.0.xsd"
+>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<id>Hotspot-1.8</id>
+			<version>1.8</version>
+			<vendor>oracle</vendor>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-8-oracle</jdkHome>
+		</configuration>
+	</toolchain>
+
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<id>Hotspot-9</id>
+			<version>9</version>
+			<vendor>oracle</vendor>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-9-oracle</jdkHome>
+		</configuration>
+	</toolchain>
+
+</toolchains>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: java
+jdk: oraclejdk8
+sudo: required
+cache:
+  directories:
+  - "$HOME/.m2"
+  - "$HOME/apache-maven-3.5.4"
+  - ''
+before_install:
+- sudo add-apt-repository ppa:linuxuprising/java -y
+- sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
+- sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'
+- sudo echo 'deb http://repos.azulsystems.com/debian stable main' > /etc/apt/sources.list.d/zulu.list
+- sudo apt-get update -q
+- sudo apt-get install oracle-java10-installer oracle-java9-installer oracle-java8-installer -y
+- export JAVA_HOME=/usr/lib/jvm/java-10-oracle
+- mkdir -p $HOME/.m2
+- export M2_HOME=$HOME/apache-maven-3.5.4
+- if [ ! -d $M2_HOME/bin ]; then curl https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz | tar zxf - -C $HOME; fi
+- export PATH=$M2_HOME/bin:$PATH
+install:
+- chmod go-rwx -R $HOME/.m2
+before_script:
+- mvn -v
+script:
+- mvn --toolchains ./.ci-toolchains.xml -U clean package

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ component JSRs, but it is also valuable to allow consistency between Java EE and
 
 This standalone release of Java(TM) Common Annotations uses a
 [Java Platform Module System](http://openjdk.java.net/projects/jigsaw/spec/)
- module name of `javax.annotation`.
+ module name of `java.annotation`.

--- a/README.md
+++ b/README.md
@@ -8,5 +8,4 @@ component JSRs, but it is also valuable to allow consistency between Java EE and
 
 This standalone release of Java(TM) Common Annotations uses a
 [Java Platform Module System](http://openjdk.java.net/projects/jigsaw/spec/)
-"automatic" module name of `java.annotation`, to match the module name
-used in JDK 9.  A future version will include full module metadata.
+ module name of `javax.annotation`.

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>net.java</groupId>
-        <artifactId>jvnet-parent</artifactId>
-        <version>3</version>
+      <groupId>org.eclipse.ee4j</groupId>
+      <artifactId>project</artifactId>
+      <version>1.0</version>
     </parent>
 
     <groupId>javax.annotation</groupId>
@@ -80,6 +80,37 @@
       <tag>HEAD</tag>
   </scm>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>1.2.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>java-hamcrest</artifactId>
+			<version>2.0.0.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	
+	
     <build>
         <resources>
             <resource>
@@ -97,15 +128,49 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>
-                </configuration>
-            </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <jdkToolchain>
+                <version>9</version>
+              </jdkToolchain>
+              <release>9</release>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <configuration>
+              <jdkToolchain>
+                <version>9</version>
+              </jdkToolchain>
+              <release>9</release>
+            </configuration>
+          </execution>
+          <execution>
+            <id>base-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <jdkToolchain>
+            <version>1.8</version>
+          </jdkToolchain>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
@@ -133,7 +198,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>1.4.3</version>
+                <version>3.5.1</version>
                 <configuration>
                     <supportedProjectTypes>
                         <supportedProjectType>jar</supportedProjectType>
@@ -165,16 +230,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.2</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                        <manifestEntries>
-                            <!-- for JDK 9 -->
-                            <Automatic-Module-Name>
-                                java.annotation
-                            </Automatic-Module-Name>
-                        </manifestEntries>
                     </archive>
                     <excludes>
                         <exclude>**/*.java</exclude>
@@ -184,7 +243,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-remote-resources-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.5</version>
                 <executions>
                   <execution>
                     <goals>
@@ -201,7 +260,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
+                <version>3.0.1</version>
                 <configuration>
                     <includePom>true</includePom>
                 </configuration>
@@ -217,7 +276,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.0.1</version>
+                <configuration>
+                	<failOnWarnings>false</failOnWarnings>
+                	<failOnError>false</failOnError>
+                    <additionalOptions>
+                    	<additionalOption>-html5</additionalOption>
+                    	<additionalOption>--add-modules</additionalOption>
+                    	<additionalOption>java.sql</additionalOption>
+                    </additionalOptions>
+                </configuration>
                 <executions>
 		    <execution>
                         <id>attach-javadocs</id>
@@ -226,6 +294,7 @@
                         </goals>
 		    </execution>
                     <execution>
+                    	<!-- no such phase, should site as this is a report goal -->
                         <phase>javadoc</phase>
                         <goals>
                             <goal>javadoc</goal>
@@ -263,7 +332,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -291,19 +359,98 @@
                     </reporting>
                 </configuration>
             </plugin>
-	    <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-gpg-plugin</artifactId>
-                     <executions>
-                         <execution>
-                             <id>sign-artifacts</id>
-		             <phase>verify</phase>
-                             <goals>
-                                 <goal>sign</goal>
-                             </goals>
-                         </execution>
-                     </executions>
-	</plugin>
+            
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.0</version>
+				<inherited>true</inherited>
+				<configuration>
+					<includes>
+						<include>**/*Test.java</include>
+					</includes>
+					<excludes>
+						<exclude>**/*IntegrationTest.java</exclude>
+					</excludes>
+				</configuration>
+			</plugin>					
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.22.0</version>
+				<inherited>true</inherited>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<testFailureIgnore>false</testFailureIgnore>
+							<includes>
+								<include>**/*IntegrationTest.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<id>module-info-file-exists</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>pre-integration-test</phase>
+						<configuration>
+							<rules>
+								<requireFilesExist>
+									<files>
+										<file>${project.build.outputDirectory}/module-info.class</file>
+									</files>
+								</requireFilesExist>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.glassfish.build</groupId>
+                                        <artifactId>spec-version-maven-plugin</artifactId>
+                                        <versionRange>[1.2,)</versionRange>
+                                        <goals>
+                                            <goal>set-spec-properties</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+	                                    <execute>
+	                                    	<runOnConfiguration>true</runOnConfiguration>
+	                                    </execute>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,37 +80,37 @@
       <tag>HEAD</tag>
   </scm>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.2.0</version>
-			<scope>test</scope>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.2.0</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.2.0</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>java-hamcrest</artifactId>
-			<version>2.0.0.0</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	
-	
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    
     <build>
         <resources>
             <resource>
@@ -278,23 +278,23 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
                 <configuration>
-                	<failOnWarnings>false</failOnWarnings>
-                	<failOnError>false</failOnError>
+                    <failOnWarnings>false</failOnWarnings>
+                    <failOnError>false</failOnError>
                     <additionalOptions>
-                    	<additionalOption>-html5</additionalOption>
-                    	<additionalOption>--add-modules</additionalOption>
-                    	<additionalOption>java.sql</additionalOption>
+                        <additionalOption>-html5</additionalOption>
+                        <additionalOption>--add-modules</additionalOption>
+                        <additionalOption>java.sql</additionalOption>
                     </additionalOptions>
                 </configuration>
                 <executions>
-		    <execution>
+            <execution>
                         <id>attach-javadocs</id>
-	                <goals>
+                    <goals>
                             <goal>jar</goal>
                         </goals>
-		    </execution>
+            </execution>
                     <execution>
-                    	<!-- no such phase, should site as this is a report goal -->
+                        <!-- no such phase, should site as this is a report goal -->
                         <phase>javadoc</phase>
                         <goals>
                             <goal>javadoc</goal>
@@ -360,66 +360,66 @@
                 </configuration>
             </plugin>
             
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.0</version>
-				<inherited>true</inherited>
-				<configuration>
-					<includes>
-						<include>**/*Test.java</include>
-					</includes>
-					<excludes>
-						<exclude>**/*IntegrationTest.java</exclude>
-					</excludes>
-				</configuration>
-			</plugin>					
-			
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.22.0</version>
-				<inherited>true</inherited>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-						<configuration>
-							<testFailureIgnore>false</testFailureIgnore>
-							<includes>
-								<include>**/*IntegrationTest.java</include>
-							</includes>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M1</version>
-				<executions>
-					<execution>
-						<id>module-info-file-exists</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<phase>pre-integration-test</phase>
-						<configuration>
-							<rules>
-								<requireFilesExist>
-									<files>
-										<file>${project.build.outputDirectory}/module-info.class</file>
-									</files>
-								</requireFilesExist>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>                    
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.0</version>
+                <inherited>true</inherited>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <testFailureIgnore>false</testFailureIgnore>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <executions>
+                    <execution>
+                        <id>module-info-file-exists</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <rules>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${project.build.outputDirectory}/module-info.class</file>
+                                    </files>
+                                </requireFilesExist>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -441,9 +441,9 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-	                                    <execute>
-	                                    	<runOnConfiguration>true</runOnConfiguration>
-	                                    </execute>
+                                        <execute>
+                                            <ignore />
+                                        </execute>
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module javax.annotation {
+	
+	requires java.base;
+	
+	exports javax.annotation;
+	exports javax.annotation.security;
+	exports javax.annotation.sql;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module javax.annotation {
+module java.annotation {
 	
 	requires java.base;
 	

--- a/src/test/java/javax/annotation/EnforceJavaVersionIntegrationTest.java
+++ b/src/test/java/javax/annotation/EnforceJavaVersionIntegrationTest.java
@@ -1,0 +1,77 @@
+package javax.annotation;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.annotation.security.RolesAllowed;
+import javax.annotation.sql.DataSourceDefinition;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * {@code module-info.java} is compiled with JDK9 (or the build fails).
+ * </p>
+ *
+ * <p>
+ * This integration test ensures the source is compiled with JDK8.  JDK8 is 
+ * the minimum version as some annotations make use of {@link java.lang.annotation.Repeatable}
+ * </p>
+ */
+public class EnforceJavaVersionIntegrationTest {
+
+	private static final int CLASS_FILE_MAJOR_VERSION_8 = 52;
+	private static final byte[] CAFEBABE = { (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE };
+
+
+	@Test
+	public void ensureClassesAreTargetedForJavaVersionEight() throws IOException
+	{
+		assertJavaMajorVersion(PostConstruct.class, CLASS_FILE_MAJOR_VERSION_8);
+		assertJavaMajorVersion(RolesAllowed.class, CLASS_FILE_MAJOR_VERSION_8);
+		assertJavaMajorVersion(DataSourceDefinition.class, CLASS_FILE_MAJOR_VERSION_8);
+	}
+
+
+	private void assertJavaMajorVersion(Class<?> type, int classFileMajorVersion) throws IOException
+	{
+		String name = type.getCanonicalName().replace('.', '/') + ".class";
+		ClassLoader loader = type.getClassLoader();
+
+		try(InputStream inputStream = loader.getResourceAsStream(name)) {
+			byte[] bytes = readFirstEightBytes(inputStream);
+
+			assertMagicNumber(bytes);
+			assertTargetVersion(bytes, classFileMajorVersion);
+		}
+	}
+
+
+	private static void assertMagicNumber(byte[] compiled)
+	{
+		assertThat(compiled[0], is(CAFEBABE[0]));
+		assertThat(compiled[1], is(CAFEBABE[1]));
+		assertThat(compiled[2], is(CAFEBABE[2]));
+		assertThat(compiled[3], is(CAFEBABE[3]));
+	}
+
+
+	private void assertTargetVersion(byte[] compiled, int classFileMajorVersion)
+	{
+		int inClassFile = compiled[7];
+		assertThat(inClassFile, is(classFileMajorVersion));
+	}
+
+
+	private static byte[] readFirstEightBytes(InputStream in) throws IOException
+	{
+		byte[] buf = new byte[8];
+		int b, i = 0;
+		while((b = in.read()) != -1 && i < 8) {
+			buf[i++] = (byte) b;
+		}
+		return buf;
+	}
+}


### PR DESCRIPTION
Parent POM is now org.eclipse.ee4j:project
Added integration test to ensure code built with JDK 1.8
Added CI settings with toolchains.xml

POM left unformatted to make diff easier


I have previously [signed the ECA](https://accounts.eclipse.org/users/cmacrae/eca) (earcam@gmail.com)