### PR TITLE
[ee4j_8] fixes #23: bundle symbolic name should match artifactId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
     <properties>
         <non.final>false</non.final>
         <spec.version>1.3</spec.version>
-        <extension.name>javax.annotation</extension.name>
-        <bundle.symbolicName>javax.annotation-api</bundle.symbolicName>
+        <extension.name>jakarta.annotation</extension.name>
+        <bundle.symbolicName>jakarta.annotation-api</bundle.symbolicName>
         <vendor.name>Oracle Corporation</vendor.name>
         <implementation.vendor.id>org.glassfish</implementation.vendor.id>
         <findbugs.version>3.0.5</findbugs.version>
@@ -218,7 +218,11 @@
                     <execution>
                         <goals>
                             <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
+                            <!-- TODO:
+                            glassfish-spec-version-maven-plugin needs to be updated
+                            in order to check 'jakarta.' prefixed values in manifest entries
+                            -->
+                            <!--<goal>check-module</goal>-->
                         </goals>
                     </execution>
                 </executions>
@@ -232,8 +236,8 @@
                     </supportedProjectTypes>
                     <instructions>
                         <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                        <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                        <Extension-Name>${spec.extension.name}</Extension-Name>
+                        <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
+                        <Extension-Name>${extension.name}</Extension-Name>
                         <Implementation-Version>${spec.implementation.version}</Implementation-Version>
                         <Specification-Version>${spec.specification.version}</Specification-Version>
                         <Bundle-Description>
@@ -306,6 +310,14 @@
                                     <packages>javax.annotation</packages>
                                 </group>
                             </groups>
+                            <bottom>
+<![CDATA[Copyright &#169; 1999-2018,
+    <a href="http://www.oracle.com">Oracle</a>
+    and/or its affiliates. All Rights Reserved.
+    Use is subject to
+    <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
+]]>
+                            </bottom>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
         <non.final>false</non.final>
         <spec.version>1.3</spec.version>
         <extension.name>jakarta.annotation</extension.name>
-        <bundle.symbolicName>jakarta.annotation-api</bundle.symbolicName>
         <vendor.name>Oracle Corporation</vendor.name>
         <implementation.vendor.id>org.glassfish</implementation.vendor.id>
         <findbugs.version>3.0.5</findbugs.version>
@@ -236,8 +235,8 @@
                     </supportedProjectTypes>
                     <instructions>
                         <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                        <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
-                        <Extension-Name>${extension.name}</Extension-Name>
+                        <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
+                        <Extension-Name>${spec.extension.name}</Extension-Name>
                         <Implementation-Version>${spec.implementation.version}</Implementation-Version>
                         <Specification-Version>${spec.specification.version}</Specification-Version>
                         <Bundle-Description>


### PR DESCRIPTION
fixes #23 in ee4j_8 branch
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>