### PR TITLE
Remove @Target limitations of @Priority annotation.

### DIFF
--- a/api/src/main/java/jakarta/annotation/Priority.java
+++ b/api/src/main/java/jakarta/annotation/Priority.java
@@ -21,8 +21,8 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
 /**
- * The <code>Priority</code> annotation can be applied to classes 
- * or parameters to indicate in what order they should be used.  
+ * The <code>Priority</code> annotation can be applied to any program elements
+ * to indicate in what order they should be used.
  * The effect of using the <code>Priority</code> annotation in
  * any particular instance is defined by other specifications that 
  * define the use of a specific class.
@@ -39,7 +39,6 @@ import static java.lang.annotation.RetentionPolicy.*;
  *
  * @since Common Annotations 1.2
  */
-@Target({TYPE,PARAMETER})
 @Retention(RUNTIME)
 @Documented
 public @interface Priority {

--- a/spec/src/main/asciidoc/spec.adoc
+++ b/spec/src/main/asciidoc/spec.adoc
@@ -702,7 +702,7 @@ private Connection connection;
 === jakarta.annotation.Priority
 
 The _Priority_ annotation can be applied to
-classes or parameters to indicate in what order they should be used. The
+any program elements to indicate in what order they should be used. The
 effect of using the _Priority_ annotation in any particular instance is
 defined by other specifications that define the use of a specific class.
 
@@ -724,7 +724,6 @@ import java.lang.annotation.*;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
-@Target({TYPE, PARAMETER})
 @Retention(RUNTIME)
 @Documented
 public @interface Priority {


### PR DESCRIPTION
Fixes #86 

This is a PR for #86 that allows `@Priority` to be used on all program elements (as opposed to just types and parameters).
I've also changed the javadoc and spec doc accordingly. Let me know if I missed anything.