### PR TITLE
Nonnull and Nullable annotations added.

### DIFF
--- a/api/src/main/java/jakarta/annotation/Nonnull.java
+++ b/api/src/main/java/jakarta/annotation/Nonnull.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must not be null.
+ * <p>
+ * Annotated fields must not be null after construction has completed.
+ * <p>
+ * When this annotation is applied to a method it applies to the method return value.
+ *
+ * @see jakarta.annotation.Nullable
+ * @since 2.0
+ */
+@Documented
+@Retention(RUNTIME)
+public @interface Nonnull {
+}

--- a/api/src/main/java/jakarta/annotation/Nullable.java
+++ b/api/src/main/java/jakarta/annotation/Nullable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element could be null under some circumstances.
+ * <p>
+ * In general, this means developers will have to read the documentation to
+ * determine when a null value is acceptable and whether it is necessary to
+ * check for a null value.
+ * <p>
+ * This annotation is useful mostly for overriding a {@link Nonnull} annotation.
+ * Static analysis tools should generally treat the annotated items as though they
+ * had no annotation, unless they are configured to minimize false negatives.
+ * <p>
+ * When this annotation is applied to a method it applies to the method return value.
+ *
+ * @see jakarta.annotation.Nonnull
+ * @since 2.0
+ */
+@Documented
+@Retention(RUNTIME)
+public @interface Nullable {
+}

--- a/spec/src/main/asciidoc/annotations-spec.adoc
+++ b/spec/src/main/asciidoc/annotations-spec.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2017, 2021 Contributors to the Eclipse Foundation
 //
 
 = Jakarta Annotations

--- a/spec/src/main/asciidoc/spec.adoc
+++ b/spec/src/main/asciidoc/spec.adoc
@@ -733,6 +733,83 @@ public @interface Priority {
 }
 ----
 
+=== jakarta.annotation.Nonnull
+
+The _Nonnull_ annotation is used to mark
+elements that cannot be `null`.
+
+This information can be used for validation by IDEs, static analysis tools, and runtime.
+
+The annotation may be present on any target.
+This specification defines behavior on following targets:
+
+- Method -  return type will never be `null`
+- Parameter - parameter must not be `null`
+- Field - field cannot be `null` after construction of the object is completed
+
+[source,java]
+----
+package jakarta.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+public @interface Nonnull {
+}
+----
+
+The following example shows the usage of the annotation defined above:
+
+[source,java]
+----
+public interface StockQuoteService {
+    @Nonnull
+    BigDecimal quote(@Nonnull String marker);
+}
+----
+
+=== jakarta.annotation.Nullable
+
+The _Nullable_ annotation is used to mark
+elements that may be `null`.
+
+This information can be used for validation by IDEs, static analysis tools, and runtime.
+
+The annotation may be present on any target.
+This specification defines behavior on following targets:
+
+- Method -  return type may be `null`
+- Parameter - parameter may be `null`
+- Field - field may be `null`
+
+[source,java]
+----
+package jakarta.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+public @interface Nullable {
+}
+----
+
+The following example shows the usage of the annotation defined above:
+
+[source,java]
+----
+public interface StockQuoteService {
+    BigDecimal quote(String marker, @Nullable BigDecimal defaultValue);
+}
+----
+
 === jakarta.annotation.security.RunAs
 
 The _RunAs_ annotation defines the security


### PR DESCRIPTION
Resolves #89 

This PR adds only `Nullable` and `Nonnull` annotations from JSR 305, as these are the most commonly used and dramatically improve usability of any code using them.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>